### PR TITLE
Allow building with base-4.10.0.0

### DIFF
--- a/old-time.cabal
+++ b/old-time.cabal
@@ -53,7 +53,7 @@ Library
         HsTime.h
 
     build-depends:
-        base       >= 4.7 && < 4.9,
+        base       >= 4.7 && < 4.11,
         old-locale == 1.0.*
 
     ghc-options: -Wall

--- a/old-time.cabal
+++ b/old-time.cabal
@@ -53,7 +53,7 @@ Library
         HsTime.h
 
     build-depends:
-        base       >= 4.7 && < 4.11,
+        base       >= 4.7 && < 5,
         old-locale == 1.0.*
 
     ghc-options: -Wall


### PR DESCRIPTION
Currently, the `old-time` in this repo doesn't build with GHC 8.2 (or 8.0, for that matter!) due to restrictive upper version bounds on `base`.

(The version on Hackage does allow 8.0, but not 8.2., currently.)