### PR TITLE
Remove `includes` from `.cabal`-file

### DIFF
--- a/old-time.cabal
+++ b/old-time.cabal
@@ -63,7 +63,6 @@ Library
         cbits/timeUtils.c
 
     include-dirs: include
-    includes:     HsTime.h
     install-includes:
         HsTime.h
 


### PR DESCRIPTION
This is useless at best, and a common source of confusion.

https://github.com/haskell/cabal/pull/10145
https://github.com/sol/hpack/issues/355