### PR TITLE
ghc 9.14.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250506
+# version: 0.19.20260104
 #
-# REGENDATA ("0.19.20250506",["github","old-time.cabal"])
+# REGENDATA ("0.19.20260104",["github","old-time.cabal"])
 #
 name: Haskell-CI
 on:
@@ -18,6 +18,9 @@ on:
     branches:
       - master
   pull_request:
+    branches:
+      - master
+  merge_group:
     branches:
       - master
 jobs:
@@ -32,14 +35,19 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.14.1
+            compilerKind: ghc
+            compilerVersion: 9.14.1
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.12.2
             compilerKind: ghc
             compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.10.2
+          - compiler: ghc-9.10.3
             compilerKind: ghc
-            compilerVersion: 9.10.2
+            compilerVersion: 9.10.3
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.8.4
@@ -110,8 +118,8 @@ jobs:
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.2.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.16.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.16.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |
@@ -187,7 +195,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -215,7 +223,11 @@ jobs:
           touch cabal.project.local
           echo "packages: ${PKGDIR_old_time}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package old-time" >> cabal.project ; fi
-          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "package old-time" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90400)) -ne 0 ] ; then echo "    ghc-options: -Werror=unused-packages" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package old-time" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(old-time)$/; }' >> cabal.project.local

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog for [`old-time` package](http://hackage.haskell.org/package/old-time)
 
+## 1.1.0.5  *Jan 2026*
+
+  * Remove unused `includes` field in `.cabal` file
+    (Simon Hengel, [PR #17](https://github.com/haskell/old-time/pull/17)).
+  * Bump `cabal-version` to 1.18.
+  * Build tested with GHC 8.0 - 9.14.1.
+
 ## 1.1.0.4  *Dec 2023*
 
   * Add `build-tools: hsc2hs` to `old-time.cabal` for compilation with GHC 8.

--- a/old-time.cabal
+++ b/old-time.cabal
@@ -1,6 +1,6 @@
-cabal-version:  >=1.10
+cabal-version:  1.18
 name:           old-time
-version:        1.1.0.4
+version:        1.1.0.5
 -- NOTE: Don't forget to update ./changelog.md
 license:        BSD3
 license-file:   LICENSE
@@ -32,9 +32,11 @@ tested-with:
   GHC == 8.2.2
   GHC == 8.0.2
 
+extra-doc-files:
+    changelog.md
+
 extra-source-files:
     aclocal.m4
-    changelog.md
     config.guess
     config.sub
     configure

--- a/old-time.cabal
+++ b/old-time.cabal
@@ -17,8 +17,9 @@ description:
     is recommended.
 
 tested-with:
+  GHC == 9.14.1
   GHC == 9.12.2
-  GHC == 9.10.2
+  GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7
   GHC == 9.4.8


### PR DESCRIPTION
- **Bump Haskell CI to GHC 9.14.1**
- **v1.1.0.5: CHANGELOG**

Candidate: https://hackage.haskell.org/package/old-time-1.1.0.5/candidate
  